### PR TITLE
add: rootページのビュー・コントローラ・ルーティングを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,10 @@ gem "sassc-rails"
 # 2024/01/03
 gem "bootstrap", "~> 5.3.0"
 gem "sorcery"
-gem "rmagick"
+
+# 2024/01/13
+gem "carrierwave", "~> 3.0"
+gem "mini_magick"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,13 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    carrierwave (3.0.5)
+      activemodel (>= 6.0.0)
+      activesupport (>= 6.0.0)
+      addressable (~> 2.6)
+      image_processing (~> 1.1)
+      marcel (~> 1.0.0)
+      ssrf_filter (~> 1.0)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
     date (3.3.4)
@@ -107,6 +114,9 @@ GEM
     hashie (5.0.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
+    image_processing (1.12.2)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     importmap-rails (2.0.1)
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
@@ -130,6 +140,7 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mini_magick (4.12.0)
     mini_mime (1.1.5)
     minitest (5.20.0)
     msgpack (1.7.2)
@@ -160,7 +171,6 @@ GEM
       rack (>= 1.2, < 4)
       snaky_hash (~> 2.0)
       version_gem (~> 1.1)
-    pkg-config (1.5.6)
     popper_js (2.11.8)
     psych (5.1.2)
       stringio
@@ -206,8 +216,8 @@ GEM
     reline (0.4.2)
       io-console (~> 0.5)
     rexml (3.2.6)
-    rmagick (5.3.0)
-      pkg-config (~> 1.4)
+    ruby-vips (2.2.0)
+      ffi (~> 1.12)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     sassc (2.4.0)
@@ -236,6 +246,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    ssrf_filter (1.1.2)
     stimulus-rails (1.3.3)
       railties (>= 6.0.0)
     stringio (3.1.0)
@@ -269,13 +280,14 @@ DEPENDENCIES
   bootsnap
   bootstrap (~> 5.3.0)
   capybara
+  carrierwave (~> 3.0)
   debug
   importmap-rails
   jbuilder
+  mini_magick
   mysql2 (~> 0.5)
   puma (~> 5.0)
   rails (~> 7.0.8)
-  rmagick
   sassc-rails
   selenium-webdriver
   sorcery

--- a/app/controllers/tops_controller.rb
+++ b/app/controllers/tops_controller.rb
@@ -1,0 +1,4 @@
+class TopsController < ApplicationController
+  def top
+  end
+end

--- a/app/helpers/tops_helper.rb
+++ b/app/helpers/tops_helper.rb
@@ -1,0 +1,2 @@
+module TopsHelper
+end

--- a/app/views/tops/top.html.erb
+++ b/app/views/tops/top.html.erb
@@ -1,0 +1,2 @@
+<h1>Tops#top</h1>
+<p>Find me in app/views/tops/top.html.erb</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,3 @@
 Rails.application.routes.draw do
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-  # Defines the root path route ("/")
-  # root "articles#index"
+  root "tops#top"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,14 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.0].define(version: 0) do
+end

--- a/test/controllers/tops_controller_test.rb
+++ b/test/controllers/tops_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class TopsControllerTest < ActionDispatch::IntegrationTest
+  test "should get top" do
+    get tops_top_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## 概要

機能追加
- topページのビューとコントローラを追加しました。
- topページのルーティングを設定しました。
  - topページのルーティングをrootに設定しました。

## 確認方法

1. `localhost:3000`にアクセスし、topページ(tops#top)が表示されていることを確認してください。

## コメント

- 対戦よろしくお願いします。
