### PR TITLE
add: rootページに時計を実装

### DIFF
--- a/app/javascript/top.js
+++ b/app/javascript/top.js
@@ -1,0 +1,40 @@
+// 現在時刻(hh:mm:ss)を取得する関数
+// 表示するために取得する場合はdisplayTime、単に値として取得したい場合はdataTimeを引数に渡す。
+function whatTime(which) {
+  const now = new Date();
+
+  const hours = now.getHours();
+  const minutes = now.getMinutes();
+  const seconds = now.getSeconds();
+
+  // 時, 分, 秒について1桁の場合に0を追加
+  const displayHours = hours.toString().padStart(2, "0");
+  const displayMinutes = minutes.toString().padStart(2, "0");
+  const displaySeconds = seconds.toString().padStart(2, "0");
+
+  const displayTime = `${displayHours}:${displayMinutes}`;
+  console.log(`${displayHours}:${displayMinutes}:${displaySeconds}`); // 動作確認用コード
+
+  const dataTime = `${hours}:${minutes}:${seconds}`;
+
+  if (which === "displayTime") {
+  return displayTime;
+  }
+  
+  if (which === "dataTime") {
+  return dataTime;
+  } 
+}
+
+// 時計を更新する関数
+function updateClock() {
+  const clockElement = document.getElementById("jsclock");
+  const displayTime = whatTime("displayTime");
+
+  clockElement.textContent = displayTime;
+
+  setTimeout(updateClock, 1000);
+}
+
+// 時計を開始
+updateClock();

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,7 @@
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
+      <%= yield(:js) %>
   </head>
 
   <body>

--- a/app/views/tops/top.html.erb
+++ b/app/views/tops/top.html.erb
@@ -1,2 +1,6 @@
 <h1>Tops#top</h1>
-<p>Find me in app/views/tops/top.html.erb</p>
+<p id="jsclock">※ここに時計が表示されます。</p>
+
+<% content_for :js do %>
+  <%= javascript_import_module_tag "top" %>
+<% end %>


### PR DESCRIPTION
## 概要

- rootページ(tops#top)にデジタル表示の時計を実装しました。

## 確認方法

1. rootページにアクセスし、現在時刻が表示されていることを確認してください。
2. rootページにて検証をデベロッパーモード→コンソールを開き、1秒毎に現在時刻がコンソールに表示されることを確認してください。

## コメント

- importmap-rails、実装はできたもののその仕組みはいまいち理解できなかったのであとで調べます。