### PR TITLE
add: 現在のセクションを表示する機能を追加

### DIFF
--- a/app/controllers/tops_controller.rb
+++ b/app/controllers/tops_controller.rb
@@ -1,4 +1,8 @@
 class TopsController < ApplicationController
   def top
+    # ログイン機能実装時に書き換え予定
+    user = User.find_by(student_identification: "test")
+    timetable = user.timetable
+    @sections = timetable.sections
   end
 end

--- a/app/javascript/top.js
+++ b/app/javascript/top.js
@@ -7,7 +7,7 @@ function whatTime(which) {
   const minutes = now.getMinutes();
   const seconds = now.getSeconds();
 
-  // 時, 分, 秒について1桁の場合に0を追加
+  // 時, 分, 秒について0埋め
   const displayHours = hours.toString().padStart(2, "0");
   const displayMinutes = minutes.toString().padStart(2, "0");
   const displaySeconds = seconds.toString().padStart(2, "0");
@@ -26,7 +26,7 @@ function whatTime(which) {
   } 
 }
 
-// 時計を更新する関数
+// 時計を更新(表示)する関数
 function updateClock() {
   const clockElement = document.getElementById("jsclock");
   const displayTime = whatTime("displayTime");
@@ -36,5 +36,23 @@ function updateClock() {
   setTimeout(updateClock, 1000);
 }
 
+// 現在のセクションを更新(表示)する関数
+const sectionElement = document.getElementById("jscurrentsection");
+const sections = JSON.parse(sectionElement.dataset.sections);
+
+function updateCurrentSection(){
+  // 現在のセクションを取得（start_time以上-end_time未満の範囲に現在時刻のあるセクション）
+  const nowDataTime = whatTime("dataTime");
+  const currentSection = sections.find((section) => 
+    // time型を"%H:%M:%S"の形に一発変換できるコードが思いつかないので、時刻部分を切り離し取得する姑息な処理で妥協
+    section.start_time.split("T")[1].substring(0, 8) <= nowDataTime && section.end_time.split("T")[1].substring(0, 8) > nowDataTime
+  );
+
+  sectionElement.textContent = `name: ${currentSection.name}, start_time: ${currentSection.start_time}, end_time: ${currentSection.end_time}`
+
+  setTimeout(updateCurrentSection, 1000);
+}
+
 // 時計を開始
 updateClock();
+updateCurrentSection();

--- a/app/views/tops/top.html.erb
+++ b/app/views/tops/top.html.erb
@@ -1,5 +1,6 @@
 <h1>Tops#top</h1>
 <p id="jsclock">※ここに時計が表示されます。</p>
+<p id="jscurrentsection" data-sections=<%= @sections.to_json %>>※ここに現在のセクションが表示されます。</p>
 
 <% content_for :js do %>
   <%= javascript_import_module_tag "top" %>


### PR DESCRIPTION
## 概要

- 現在のセクションの情報(name, start_time, end_time)を表示する機能を追加しました。

## 確認方法

1. `$ rails c`でコンソールを開き、各テーブルの適当なレコードをそれぞれ作成してください。このとき、sectionsテーブルのデータのstart_timeおよびend_timeの値は、現在時刻に近い値に設定してください。
2. 各データ作成後、rootページに移動し、現在のセクションの情報が表示されていることを確認してください。
3. 可能なら、現在のセクションが変わった場合、rootページに表示される情報も変わることを確認してください。

## コメント

- `app/javascript/top.js`のjs:47にもあるとおり、time型を`%H:%M:%S`の形に一発で変換する方法が思いつきませんでした（javascriptだとstrftimeがない）。良い案があったら教えていただけるとありがたいです。