### PR TITLE
add: aboutページのルーティングを追加

### DIFF
--- a/app/controllers/abouts_controller.rb
+++ b/app/controllers/abouts_controller.rb
@@ -1,0 +1,4 @@
+class AboutsController < ApplicationController
+  def about
+  end
+end

--- a/app/helpers/abouts_helper.rb
+++ b/app/helpers/abouts_helper.rb
@@ -1,0 +1,2 @@
+module AboutsHelper
+end

--- a/app/views/abouts/about.html.erb
+++ b/app/views/abouts/about.html.erb
@@ -1,0 +1,2 @@
+<h1>Abouts#about</h1>
+<p>Find me in app/views/abouts/about.html.erb</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
+  get "about" => "abouts#about"
   root "tops#top"
 end

--- a/test/controllers/abouts_controller_test.rb
+++ b/test/controllers/abouts_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class AboutsControllerTest < ActionDispatch::IntegrationTest
+  test "should get about" do
+    get abouts_about_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## 概要

- aboutページのルーティングを設定しました。

## 確認方法

1. `localhost:3000/about`に訪れると、abouts#aboutページの表示されることを確認してください。

## コメント

- 特にありません。