### PR TITLE
add: aboutページのモーダル化を追加

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -36,7 +36,6 @@ body {
         top: 10px;
         left: -400%;
         padding-right: 20px;
-        z-index: 100;
         border-radius: 4px;
         background-color: rgba(245,245,245,0.7);
         opacity: 0;
@@ -50,6 +49,13 @@ body {
             transition: color 0.2s 0s linear;
           }
           a:hover {
+            color: #7d8bf0;
+          }
+          button {
+            color: #808080;
+            transition: color 0.2s 0s linear;
+          }
+          button:hover {
             color: #7d8bf0;
           }
         }
@@ -68,15 +74,15 @@ body {
     line-height: 60px;
   }
 
-  #js-clock {
+  #jsClock {
     font-size: 60px;
   }
 
-  #js-currentsection-name {
+  #jsCurrentsectionName {
     font-size: 48px;
   }
 
-  #js-currentsection-start-end {
+  #jsCurrentsectionStartEnd {
     font-size: 16px;
     line-height: 12px;
   }
@@ -88,7 +94,7 @@ body {
     right: 28px;
     bottom: 30px;
 
-    #root-volume-button {
+    #rootVolumeButton {
       cursor: pointer;
       position: fixed;
       right: 28px;
@@ -99,11 +105,11 @@ body {
         #fff -1px 0 0, #fff 1px 0 0;
       transition: color 0.2s 0s linear;
     }
-    #root-volume-button:hover {
+    #rootVolumeButton:hover {
       color: #454545;
     }
 
-    #root-volume-controller {
+    #rootVolumeController {
       position: relative;
       background-color: rgba(255, 255, 255, 0.7);
       border: 1px solid rgba(0, 0, 0, 0.7);

--- a/app/controllers/abouts_controller.rb
+++ b/app/controllers/abouts_controller.rb
@@ -1,4 +1,0 @@
-class AboutsController < ApplicationController
-  def about
-  end
-end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,7 +1,5 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
-//= require jquery3
-//= require popper
-//= require bootstrap
+//= require jquery
 import "@hotwired/turbo-rails"
 import "controllers"
 import "top"

--- a/app/javascript/top.js
+++ b/app/javascript/top.js
@@ -13,7 +13,7 @@
 
 /* -----------    汎用変数/汎用関数    ----------- */
 // 適用中のtimetableのsections（開始時刻順）
-const sectionsDataEl = document.getElementById("js-sections-data");
+const sectionsDataEl = document.getElementById("jsSectionsData");
 const sections = JSON.parse(sectionsDataEl.dataset.sections).sort( (a, b) => a.start_time.localeCompare(b.start_time) );
 
 // 関数：現在時刻を取得
@@ -44,8 +44,8 @@ function sleep(waitTimeMilliSeconds) {
 
 /* -----------    その他の処理    ----------- */
 // ハンバーガーメニューの表示・非表示
-const hamburgerMenuBtnEl = document.getElementById("hamburger-menu-btn");
-const menuContentEl = document.getElementById("menu-content");
+const hamburgerMenuBtnEl = document.getElementById("hamburgerMenuBtn");
+const menuContentEl = document.getElementById("menuContent");
 function existLeft(el) { el.style.left = "-400%"; }
 hamburgerMenuBtnEl.addEventListener("click", () => {
   if (menuContentEl.style.opacity == 0) {
@@ -57,16 +57,17 @@ hamburgerMenuBtnEl.addEventListener("click", () => {
   }
 })
 document.addEventListener("click", (e) => {
-  if (!e.target.closest("#menu-content") && e.target !== hamburgerMenuBtnEl) { 
+  if (!e.target.closest("#menuContent") && e.target !== hamburgerMenuBtnEl) { 
     menuContentEl.style.opacity = 0;
     setTimeout(existLeft, 200, menuContentEl); }
 })
 
 
+
 /* -----------    assets関連    ----------- */
 // 音量スライダーの表示・非表示
-const rootVolumeButtonEl = document.getElementById("root-volume-button");
-const rootVolumeControllerEl = document.getElementById("root-volume-controller");
+const rootVolumeButtonEl = document.getElementById("rootVolumeButton");
+const rootVolumeControllerEl = document.getElementById("rootVolumeController");
 function existRight(el) { el.style.right = "-400%"; }
 /// 音量アイコンクリック時、音量スライダーを表示・非表示
 rootVolumeButtonEl.addEventListener("click", () => {
@@ -80,7 +81,7 @@ rootVolumeButtonEl.addEventListener("click", () => {
 })
 /// 音量スライダーの要素外をクリック時、音量スライダー要素を非表示
 document.addEventListener("click", (e) => {
-  if (!e.target.closest("#root-volume-controller") && e.target !== rootVolumeButtonEl) { 
+  if (!e.target.closest("#rootVolumeController") && e.target !== rootVolumeButtonEl) { 
     rootVolumeControllerEl.style.opacity = 0;
     setTimeout(existRight, 200, rootVolumeControllerEl);
   }
@@ -90,7 +91,7 @@ document.addEventListener("click", (e) => {
 /// 音色
 const chime = new Audio("/assets/Japanese_School_Bell02-01(Slow-Long).mp3");
 /// 初期音量
-const inputChimeVolume = document.getElementById("chimevolume");
+const inputChimeVolume = document.getElementById("chimeVolume");
 const defaultChimeVolume = inputChimeVolume.value;
 chime.volume = defaultChimeVolume;
 /// 音量スライダー
@@ -111,7 +112,7 @@ function setCurrentBgm() {
 }
 let bgm = setCurrentBgm();
 /// 初期音量
-const inputBgmVolume = document.getElementById("bgmvolume");
+const inputBgmVolume = document.getElementById("bgmVolume");
 const defaultBgmVolume = inputBgmVolume.value;
 bgm.volume = defaultBgmVolume;
 /// 音量スライダー
@@ -175,34 +176,21 @@ function startLoopBgm() {
     clearTimeout(loopPlayTimer);
   }
 
-/*
-// クリック時(音量確認に返答後)、BGMを鳴らす
-document.addEventListener("DOMContentLoaded", function() {
-  document.addEventListener("click", function() {
-    if (checkClicked) { return; }
-    if (bgm.paused) {
-      playBgm();
-      checkClicked = ture;
-    }
-  });
-});
-*/
-
 
 
 /* -----------    everySecondに関する関数群    ----------- */
   /* -----------    時計に関する関数    ----------- */
   // 関数：時計を表示
   function displayClock() { 
-    const clockEl = document.getElementById("js-clock");
+    const clockEl = document.getElementById("jsClock");
     clockEl.textContent = theTime;
   }
 
   /* -----------    セクション表示に関する関数    ----------- */
   // 関数：セクションを表示
   function displaySection() {
-    const currentsectionNameEl = document.getElementById("js-currentsection-name");
-    const currentsectionStartEndEl = document.getElementById("js-currentsection-start-end");
+    const currentsectionNameEl = document.getElementById("jsCurrentsectionName");
+    const currentsectionStartEndEl = document.getElementById("jsCurrentsectionStartEnd");
 
     if (currentSection) {
       currentsectionNameEl.textContent = `${currentSection.name}`;
@@ -338,5 +326,11 @@ document.addEventListener("DOMContentLoaded", function() {
 
 
 /* -----------    start-upの処理を実行    ----------- */
+
 everySecond();
-startLoopBgm();
+let checkClicked;
+document.addEventListener("click", function() {
+  if (checkClicked) { return; }
+  startLoopBgm();
+  checkClicked = true;
+});

--- a/app/views/abouts/about.html.erb
+++ b/app/views/abouts/about.html.erb
@@ -1,2 +1,0 @@
-<h1>Abouts#about</h1>
-<p>Find me in app/views/abouts/about.html.erb</p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,7 @@
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
     <%= yield(:js) %>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
   </head>
 
   <body>

--- a/app/views/tops/top.html.erb
+++ b/app/views/tops/top.html.erb
@@ -2,18 +2,18 @@
   <div class="fixed-top">
     <div class="left-top" id="left-top">
       <div class="hamburger-menu">
-        <span class="hamburger-menu-btn" id="hamburger-menu-btn">≡</span>
+        <span class="hamburger-menu-btn" id="hamburgerMenuBtn">≡</span>
 
-        <div class="menu-content" id="menu-content">
+        <div class="menu-content" id="menuContent">
           <ul>
             <li>
-                <a href="#">メニューリンク1</a>
+              <button type="button" class="btn btn-link" data-bs-toggle="modal" data-bs-target="#aboutModal">about</button>
             </li>
             <li>
-                <a href="#">メニューリンク2</a>
+              <a href="#">メニューリンク2</a>
             </li>
             <li>
-                <a href="#">メニューリンク3</a>
+              <a href="#">メニューリンク3</a>
             </li>
           </ul>
         </div>
@@ -21,25 +21,44 @@
     </div>
   </div>
 
+  <!-- Modal -->
+  <div class="modal fade" id="aboutModal" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h1 class="modal-title fs-5" id="exampleModalLabel">about</h1>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          ...
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <!-- Modal -->
+
   <div class="js-div position-absolute top-50 start-50 translate-middle">
-    <span id="js-sections-data" data-sections=<%= @sections.to_json %>></span>
-    <p class="text-center" id="js-clock">※ここに時計が表示されます。</p>
-    <p class="text-center" id="js-currentsection-name">※ここに現在のセクション名が表示されます。</p>
-    <p class="text-center" id="js-currentsection-start-end">※ここに現在のセクションの開始時刻/終了時刻が表示されます。</p>
+    <span id="jsSectionsData" data-sections=<%= @sections.to_json %>></span>
+    <p class="text-center" id="jsClock">※ここに時計が表示されます。</p>
+    <p class="text-center" id="jsCurrentsectionName">※ここに現在のセクション名が表示されます。</p>
+    <p class="text-center" id="jsCurrentsectionStartEnd">※ここに現在のセクションの開始時刻/終了時刻が表示されます。</p>
   </div>
 
   <div class="fixed-bottom">
     <div class="right-bottom">
-      <i class="fa-lg fa-solid fa-volume-low" id="root-volume-button"></i>
+      <i class="fa-lg fa-solid fa-volume-low" id="rootVolumeButton"></i>
 
-      <div class="root-volume-controller" id="root-volume-controller">
+      <div class="root-volume-controller" id="rootVolumeController">
         <div class="slider-container">
           <label for="bgmvolume">BGM</label>
-          <input type="range" name="bgmvolume" id="bgmvolume" min="0.0" max="1.0" value="0.5" step="0.01">
+          <input type="range" name="bgmvolume" id="bgmVolume" min="0.0" max="1.0" value="0.5" step="0.01">
         </div>
         <div class="slider-container">
           <label for="chimevolume">CHIME</label>
-          <input type="range" name="chimevolume" id="chimevolume" min="0.0" max="1.0" value="0.5" step="0.01">
+          <input type="range" name="chimevolume" id="chimeVolume" min="0.0" max="1.0" value="0.5" step="0.01">
         </div>
       </div>
     </div>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -6,5 +6,3 @@ pin "@hotwired/stimulus", to: "stimulus.min.js"
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
 pin_all_from "app/javascript/controllers", under: "controllers"
 pin "top"
-pin "bootstrap", to: "bootstrap.min.js", preload: true
-pin "@popperjs/core", to: "popper.js", preload: true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,3 @@
 Rails.application.routes.draw do
   root "tops#top"
-
-  get "about" => "abouts#about"
 end


### PR DESCRIPTION
## 概要

- aboutページをモーダル化しました。
  - それに伴い、aboutのview・controller・ルーティングを削除しました。
- ハンバーガーメニューにaboutを追加しました。
- 画面のどこかをクリックするとBGMが開始するようにしました。

## 確認方法

1. 画面のどこかをクリックするとBGMがフェードインすることを確認してください。
2. ハンバーガーメニューのリスト１つめに`about`が表示されていることを確認してください。
3. 当該`about`をクリックするとモーダルウィンドウが表示されることを確認してください。
4. BGMがループすることを確認してください。

## コメント

- bootstrap5用のjavascriptをgem経由で導入する方法がどうしてもわからなかったので、javascriptに関してはheadタグでCDNを利用することにしました。
- その影響か、あるいは別の原因のせいか、BGMが自動で再生されなくなりました。元々どうして自動再生されるのかよくわかっていなかったので、このままクリックによる再生を正処理とし、あとで音声確認のスプラッシュページを実装することにします。