### PR TITLE
add: viewに内容を追加

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -37,7 +37,7 @@ body {
         left: -400%;
         padding-right: 20px;
         border-radius: 4px;
-        background-color: rgba(245,245,245,0.7);
+        background-color: rgba(245,245,245,0.9);
         opacity: 0;
         transition: opacity 0.2s 0s linear;
 

--- a/app/views/tops/top.html.erb
+++ b/app/views/tops/top.html.erb
@@ -7,7 +7,7 @@
         <div class="menu-content" id="menuContent">
           <ul>
             <li>
-              <button type="button" class="btn btn-link" data-bs-toggle="modal" data-bs-target="#aboutModal">about</button>
+              <button type="button" class="btn btn-link" data-bs-toggle="modal" data-bs-target="#aboutModal">概要・使い方</button>
             </li>
             <li>
               <a href="#">メニューリンク2</a>
@@ -26,11 +26,21 @@
     <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
       <div class="modal-content">
         <div class="modal-header">
-          <h1 class="modal-title fs-5" id="exampleModalLabel">about</h1>
+          <h1 class="modal-title fs-5" id="exampleModalLabel">概要・使い方</h1>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body">
-          ...
+          <ul>
+            <br>
+            <li>"gakkou"は、日本の学校の空気感、<br>その再現・表現を目的としたアプリです。</li>
+            <br>
+            <li>基本的に操作は不要です。</li>
+            <br>
+            <li>定刻になるとチャイムが鳴ります。</li>
+            <br>
+            <li>学籍登録(後日実装予定)を行うと、<br>表示されるセクション名やチャイムのなる時刻を編集できるようになります。</li>
+            <br>
+            <p class="text-end" style="font-size:12px; opacity:0.5;">チャイム音提供: OtoLogic(https://otologic.jp)</p>
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
@@ -42,9 +52,9 @@
 
   <div class="js-div position-absolute top-50 start-50 translate-middle">
     <span id="jsSectionsData" data-sections=<%= @sections.to_json %>></span>
-    <p class="text-center" id="jsClock">※ここに時計が表示されます。</p>
-    <p class="text-center" id="jsCurrentsectionName">※ここに現在のセクション名が表示されます。</p>
-    <p class="text-center" id="jsCurrentsectionStartEnd">※ここに現在のセクションの開始時刻/終了時刻が表示されます。</p>
+    <p class="text-center" id="jsClock"></p>
+    <p class="text-center" id="jsCurrentsectionName"></p>
+    <p class="text-center" id="jsCurrentsectionStartEnd"></p>
   </div>
 
   <div class="fixed-bottom">


### PR DESCRIPTION
## 概要

- aboutに内容を追加しました。

## 確認方法

1. ハンバーガーメニューの`概要・使い方`を開いたとき、モーダルウィンドウに「概要・使い方」についての内容がリストで書かれていることを確認してください。
2. aboutモーダルの右下部に半透明・小文字で「チャイム音提供: OtoLogic(https://otologic.jp)」と書かれていることを確認してください。

## コメント

- 「概要・使い方」１つめの項(コンセプト部分)については、あとで変更するかもしれません。
- 読み込み時に見栄えが悪いので、時計部分やセクション名部分に元々置かれていたテキストは削除しました。