### PR TITLE
add: 音量確認ページ及び機能を追加, fix: ブラウザバック時 一定時間BGMが流れないバグを修正

### DIFF
--- a/app/assets/stylesheets/verify.scss
+++ b/app/assets/stylesheets/verify.scss
@@ -1,0 +1,35 @@
+body {
+  background-color: rgb(245, 245, 245);
+  opacity: 0.8;
+}
+
+#verifyYesButton {
+  text-decoration: none;
+  cursor: pointer;
+  color: #696969;
+  text-shadow: #fff 1px 1px 0, #fff -1px -1px 0, #fff -1px 1px 0,
+    #fff 1px -1px 0, #fff 0px 1px 0, #fff 0 -1px 0,
+    #fff -1px 0 0, #fff 1px 0 0,
+    #333 1.5px 1.5px 0, #333 -1.5px -1.5px 0, #333 -1.5px 1.5px 0,
+    #333 1.5px -1.5px 0, #333 0px 1.5px 0, #333 0 -1.5px 0,
+    #333 -1.5px 0 0, #333 1.5px 0 0,;
+  transition: color 0.2s 0s linear;
+}
+#verifyYesButton:hover {
+  color: #9f9dfe;
+}
+#verifyNoButton {
+  text-decoration: none;
+  cursor: pointer;
+  color: #696969;
+  text-shadow: #fff 1px 1px 0, #fff -1px -1px 0, #fff -1px 1px 0,
+    #fff 1px -1px 0, #fff 0px 1px 0, #fff 0 -1px 0,
+    #fff -1px 0 0, #fff 1px 0 0,
+    #333 1.5px 1.5px 0, #333 -1.5px -1.5px 0, #333 -1.5px 1.5px 0,
+    #333 1.5px -1.5px 0, #333 0px 1.5px 0, #333 0 -1.5px 0,
+    #333 -1.5px 0 0, #333 1.5px 0 0,;
+  transition: color 0.2s 0s linear;
+}
+#verifyNoButton:hover {
+  color: #c7c7c7;
+}

--- a/app/controllers/tops_controller.rb
+++ b/app/controllers/tops_controller.rb
@@ -1,6 +1,38 @@
 class TopsController < ApplicationController
+  before_action :verify_volume_enabled, only: %i[top]
+
   def top
     # ログイン機能実装時に書き換え予定
     @sections = default_sections
+    @default_bgm_volume_value = cookies[:bgm_volume_value]
+    cookies[:chime_volume_value].blank? ? @default_chime_volume_value = 0.5 : @default_chime_volume_value = cookies[:chime_volume_value]
+  end
+
+  def verify_volume
+    if cookies[:bgm_volume_value].present?
+      redirect_to root_path
+    end
+  end
+
+  def verify_yes
+    write_volume_enabled_cookie(0.5)
+    redirect_to root_path
+  end
+
+  def verify_no
+    write_volume_enabled_cookie(0.0)
+    redirect_to root_path
+  end
+
+  private
+
+  def verify_volume_enabled
+    if cookies[:bgm_volume_value].blank?
+      redirect_to verify_volume_path
+    end
+  end
+
+  def write_volume_enabled_cookie(bgm_volume_value)
+    cookies[:bgm_volume_value] = { value: bgm_volume_value }
   end
 end

--- a/app/javascript/top.js
+++ b/app/javascript/top.js
@@ -75,6 +75,7 @@ chime.volume = defaultChimeVolume;
 /// 音量スライダー
 inputChimeVolume.addEventListener("input", (e) => {
   chime.volume = e.currentTarget.value;
+  document.cookie = `chime_volume_value=${e.currentTarget.value}`;
 });
 
 // BGM
@@ -99,6 +100,7 @@ let latestBgmVolume;
 inputBgmVolume.addEventListener("input", (e) => {
   if (temporaryEnabled) {return;}  /// フェードイン・アウト中は音量スライダーを無効
   bgm.volume = e.currentTarget.value;
+  document.cookie = `bgm_volume_value=${e.currentTarget.value}`;
   latestBgmVolume = bgm.volume;
 });
 
@@ -121,6 +123,7 @@ displayCurrentBackgroundImage();
 
 /* -----------    start-up関数群    ----------- */
 // 関数：特定の処理を毎秒実行
+let checkLoopBgmStarted
 function everySecond() {
   theTime = obtainTheTime();
   currentSection = obtainCurrentSection();
@@ -129,8 +132,19 @@ function everySecond() {
   displaySection();
   checkSectionUpdated();
 
+  /// ブラウザバック時にBGMが自動再生されない問題への対策-1
+  if (!checkLoopBgmStarted) {
+    startLoopBgm();
+    checkLoopBgmStarted = true;
+  }
+
   setTimeout(everySecond, 1000);
 }
+/// ブラウザバック時にBGMが自動再生されない問題への対策-2
+window.addEventListener("beforeunload", function() {
+  stopLoopBgm();
+  checkLoopBgmStarted = false;
+});
 
 // 関数：BGMを開始
 function startLoopBgm() {
@@ -304,11 +318,4 @@ function startLoopBgm() {
 
 
 /* -----------    start-upの処理を実行    ----------- */
-
 everySecond();
-let checkClicked;
-document.addEventListener("click", function() {
-  if (checkClicked) { return; }
-  startLoopBgm();
-  checkClicked = true;
-});

--- a/app/views/tops/_volume_controller.html.erb
+++ b/app/views/tops/_volume_controller.html.erb
@@ -3,10 +3,10 @@
 <div class="volume-controller" id="volumeController">
   <div class="slider-container">
     <label for="bgmvolume">BGM</label>
-    <input type="range" name="bgmvolume" id="bgmVolume" min="0.0" max="1.0" value="0.5" step="0.01">
+    <input type="range" name="bgmvolume" id="bgmVolume" min=0.0 max=1.0 value=<%= bgm_volume_value %> step=0.01>
   </div>
   <div class="slider-container">
     <label for="chimevolume">CHIME</label>
-    <input type="range" name="chimevolume" id="chimeVolume" min="0.0" max="1.0" value="0.5" step="0.01">
+    <input type="range" name="chimevolume" id="chimeVolume" min=0.0 max=1.0 value=<%= chime_volume_value %> step=0.01>
   </div>
 </div>

--- a/app/views/tops/top.html.erb
+++ b/app/views/tops/top.html.erb
@@ -7,7 +7,7 @@
 
 <div class="fixed-bottom">
   <div class="right-bottom">
-    <%= render "volume_controller" %>
+    <%= render "volume_controller", { bgm_volume_value: @default_bgm_volume_value, chime_volume_value: @default_chime_volume_value} %>
   </div>
 </div>
 

--- a/app/views/tops/verify_volume.html.erb
+++ b/app/views/tops/verify_volume.html.erb
@@ -1,0 +1,23 @@
+<div class="text-center position-absolute top-50 start-50 translate-middle">
+  <h1>音量確認</h1>
+  <div class="m-5">
+    <p>このサイトでは音声(BGM)が流れます。</p>
+    <p>よろしいですか？</p>
+    <p>（BGMをOFFにしてもチャイムは再生されます）
+    <br>
+    <div class="mx-auto d-inline">
+      <div class="sound-on m-4 float-start">
+        <a class="fa-3x fa-solid fa-volume-high mb-3" id="verifyYesButton" href=<%= verify_yes_path %>></a>
+        <p>BGMをONにする</p>
+      </div>
+      <div class="sound-off m-4 float-end d-inline">
+        <a class="fa-3x fa-solid fa-volume-xmark mb-3" id="verifyNoButton" href=<%= verify_no_path %>></a>
+        <p>BGMをOFFにする</p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<% content_for :css do %>
+  <%= stylesheet_link_tag "verify" %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,10 @@
 Rails.application.routes.draw do
   root "tops#top"
 
+  get "verify_volume", to: "tops#verify_volume", as: :verify_volume
+  get "verify_yes", to: "tops#verify_yes", as: :verify_yes
+  get "verify_no", to: "tops#verify_no", as: :verify_no
+
   resources :contacts, only: %i[new create] do
     collection do
       post "check", to: "contacts#check"


### PR DESCRIPTION
## 概要

- 音量確認ページを追加しました。
- ブラウザバックによってトップページに遷移した場合、BGMが一定時間再生されないバグを修正しました。

## 確認方法

1. トップページにアクセス時、音量確認ページにリダイレクトされることを確認してください。
2. 「ONにする」の方をクリックすると、トップページに遷移後、BGMが再生されることを確認してください。
3. BGMやチャイムの音量スライダーを操作後、画面遷移をしたのち、トップページにアクセスすると、BGMやチャイムの音量が直前の値に引き継がれていることを確認してください。
4. デベロッパーツールなどでcookieからbgm_volume_valueを削除後、トップページにアクセスすると、音量確認ページにリダイレクトされることを確認してください。
5. 「OFFにする」の方をクリックすると、トップページに遷移後、BGMの音量が０になっていることを確認してください。
6. トップページから画面遷移をしたのち、ブラウザバックによってトップページに訪れると、BGMが最初から再生されることを確認してください。

## 影響範囲

- トップページ（javascript部分）
  - BGM再生部分のコードを弄ったため。

## コメント

- 音量確認ページを設けたことで、最初にクリックを行わずとも自動再生できるようになったので、どこかをクリックするとBGMが流れるようになるaddEventListener部分は削除しました。