### PR TITLE
add: ページタイトルを追加

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,10 @@
 module ApplicationHelper
+  def full_title(page_title = "")
+    base_title = "Gakkou"
+    if page_title.empty?
+      base_title
+    else
+      "#{page_title} | #{base_title}"
+    end
+  end
 end

--- a/app/views/contacts/check.html.erb
+++ b/app/views/contacts/check.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, "お問い合わせ内容確認" %>
+
 <div class="mx-auto">
   <h1 class="text-center p-5">お問い合わせ内容確認</h1>
   <div class="contact-explanation mx-auto">

--- a/app/views/contacts/completed.html.erb
+++ b/app/views/contacts/completed.html.erb
@@ -1,5 +1,7 @@
+<% content_for :title, "お問い合わせ完了" %>
+
 <div class="mx-auto">
-  <h1 class="text-center p-5">お問い合わせ内容確認</h1>
+  <h1 class="text-center p-5">お問い合わせ完了</h1>
   <div class="contact-explanation mx-auto position-absolute top-50 start-50 translate-middle">
     <br>
     <p>お問い合わせが完了いたしました。</p>

--- a/app/views/contacts/new.html.erb
+++ b/app/views/contacts/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, "お問い合わせフォーム" %>
+
 <div class="mx-auto">
   <h1 class="text-center p-5">お問い合わせフォーム</h1>
   <div class="contact-explanation mx-auto">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Gakkou</title>
+    <title><%= full_title(yield(:title)) %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>

--- a/app/views/tops/verify_volume.html.erb
+++ b/app/views/tops/verify_volume.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, "音量確認" %>
+
 <div class="text-center position-absolute top-50 start-50 translate-middle">
   <h1>音量確認</h1>
   <div class="m-5">


### PR DESCRIPTION
## 概要

- `verify_volume`, `contacts/new`, `contacts/check`, `contacts/completed`ページにページタイトルを追加しました。

## 確認方法

1. 先に記載した四つのページにアクセスし、ページタイトルが各ページの見出しと一致していることを確認してください。
2. 他のページではページタイトルが`Gakkou`となっていることを確認してください。

## コメント

- 特にありません。